### PR TITLE
Add course management to organize lessons

### DIFF
--- a/RoadtoGlory v0.4.html
+++ b/RoadtoGlory v0.4.html
@@ -88,6 +88,7 @@
 
         // Keys for storing data in localStorage and IndexedDB
         const LOCAL_STORAGE_KEY = 'chineseVocabLessons';
+        const COURSE_STORAGE_KEY = 'chineseVocabCourses';
         const DB_NAME = 'ChineseVocabDB';
         const STORE_NAME = 'audioFiles';
         const DB_VERSION = 1;
@@ -316,6 +317,7 @@
 
         // --- Main App Component ---
         const App = () => {
+            const [courses, setCourses] = useState([]);
             const [lessons, setLessons] = useState([]);
             const [vocabularies, setVocabularies] = useState([]);
             const [loading, setLoading] = useState(true);
@@ -328,7 +330,12 @@
 
             // Form states for creating/editing a lesson
             const [lessonName, setLessonName] = useState('');
+            const [lessonCourseId, setLessonCourseId] = useState('');
             const [editingLesson, setEditingLesson] = useState(null);
+
+            // Form states for creating/editing a course
+            const [courseName, setCourseName] = useState('');
+            const [editingCourse, setEditingCourse] = useState(null);
 
             // Form states for creating/editing a vocabulary
             const [editingVocab, setEditingVocab] = useState(null);
@@ -469,10 +476,13 @@
                 console.log("Attempting to load data from localStorage...");
                 try {
                     const storedLessons = localStorage.getItem(LOCAL_STORAGE_KEY);
+                    const storedCourses = localStorage.getItem(COURSE_STORAGE_KEY);
+                    let loadedCourses = storedCourses ? JSON.parse(storedCourses) : [];
+                    let hydratedLessons = [];
                     if (storedLessons) {
                         const parsedLessons = JSON.parse(storedLessons);
                         console.log("Parsed lessons from localStorage:", parsedLessons);
-                        const hydratedLessons = parsedLessons.map(lesson => {
+                        hydratedLessons = parsedLessons.map(lesson => {
                             const createdAtDate = safeParseDate(lesson.createdAt);
                             const updatedAtDate = safeParseDate(lesson.updatedAt);
 
@@ -495,21 +505,29 @@
                                 passages: (lesson.passages || []).map(passage => {
                                     return {
                                         ...passage,
-                                        sentences: (passage.sentences || []).map(sentence => {
-                                            return {
-                                                ...sentence,
-                                                speaker: sentence.speaker || '',
-                                            };
-                                        })
+                                        sentences: (passage.sentences || []).map(sentence => ({
+                                            ...sentence,
+                                            speaker: sentence.speaker || '',
+                                        }))
                                     };
                                 })
                             };
                         });
-                        setLessons(hydratedLessons);
-                        console.log("Hydrated lessons set:", hydratedLessons);
-                        fetchAllVocabulariesFromCurrentLessons(hydratedLessons);
                     } else {
                         console.log("No lessons found in localStorage.");
+                    }
+
+                    if (loadedCourses.length === 0) {
+                        const defaultCourse = { id: `course-${Date.now()}`, name: 'Khoá học mặc định', expanded: true };
+                        loadedCourses = [defaultCourse];
+                    }
+
+                    hydratedLessons = hydratedLessons.map(lesson => ({ ...lesson, courseId: lesson.courseId || loadedCourses[0].id }));
+
+                    setCourses(loadedCourses);
+                    setLessons(hydratedLessons);
+                    if (hydratedLessons.length > 0) {
+                        fetchAllVocabulariesFromCurrentLessons(hydratedLessons);
                     }
 
                     const storedTargetDate = localStorage.getItem('chineseTargetDate');
@@ -541,6 +559,7 @@
                     try {
                         const serializableLessons = lessons.map(lesson => ({
                             ...lesson,
+                            courseId: lesson.courseId,
                             createdAt: (lesson.createdAt instanceof Date) ? lesson.createdAt.toISOString() : new Date().toISOString(),
                             ...(lesson.updatedAt instanceof Date && { updatedAt: lesson.updatedAt.toISOString() }),
                             vocabularies: (lesson.vocabularies || []).map(vocab => ({
@@ -574,6 +593,12 @@
                     }
                 }
             }, [lessons, loading]);
+
+            useEffect(() => {
+                if (!loading) {
+                    localStorage.setItem(COURSE_STORAGE_KEY, JSON.stringify(courses));
+                }
+            }, [courses, loading]);
 
             useEffect(() => {
                 if (selectedLesson) {
@@ -617,12 +642,14 @@
                     name: lessonName,
                     createdAt: new Date(),
                     vocabularies: [],
-                    passages: []
+                    passages: [],
+                    courseId: lessonCourseId || (courses[0] ? courses[0].id : null)
                 };
 
                 setLessons(prevLessons => [...prevLessons, newLesson]);
                 setMessage({ text: "Bài học đã được tạo thành công!", type: "success" });
                 setLessonName('');
+                setLessonCourseId('');
                 setView('lessonList');
                 console.log("Created new lesson locally:", newLesson);
             };
@@ -630,6 +657,7 @@
             const handleEditLesson = (lesson) => {
                 setEditingLesson(lesson);
                 setLessonName(lesson.name);
+                setLessonCourseId(lesson.courseId);
                 setView('editLesson');
                 console.log("Entering edit lesson mode for:", lesson);
             };
@@ -645,12 +673,13 @@
                 setLessons(prevLessons =>
                     prevLessons.map(lesson =>
                         lesson.id === editingLesson.id
-                            ? { ...lesson, name: lessonName, updatedAt: new Date() }
+                            ? { ...lesson, name: lessonName, courseId: lessonCourseId, updatedAt: new Date() }
                             : lesson
                     )
                 );
                 setMessage({ text: "Tên bài học đã được cập nhật!", type: "success" });
                 setLessonName('');
+                setLessonCourseId('');
                 setEditingLesson(null);
                 setView('lessonList');
                 console.log("Updated lesson name locally to:", lessonName);
@@ -658,23 +687,31 @@
 
             const handleMoveLesson = (lessonId, direction) => {
                 setLessons(prevLessons => {
-                    const newLessons = [...prevLessons];
-                    const index = newLessons.findIndex(lesson => lesson.id === lessonId);
-
-                    if (index === -1) return newLessons;
-
+                    const index = prevLessons.findIndex(lesson => lesson.id === lessonId);
+                    if (index === -1) return prevLessons;
+                    const courseId = prevLessons[index].courseId;
+                    let targetIndex = index;
                     if (direction === 'up') {
-                        if (index > 0) {
-                            [newLessons[index - 1], newLessons[index]] = [newLessons[index], newLessons[index - 1]];
+                        for (let i = index - 1; i >= 0; i--) {
+                            if (prevLessons[i].courseId === courseId) { targetIndex = i; break; }
                         }
                     } else if (direction === 'down') {
-                        if (index < newLessons.length - 1) {
-                            [newLessons[index + 1], newLessons[index]] = [newLessons[index], newLessons[index + 1]];
+                        for (let i = index + 1; i < prevLessons.length; i++) {
+                            if (prevLessons[i].courseId === courseId) { targetIndex = i; break; }
                         }
                     }
-                    console.log("Moved lesson locally:", lessonId, "direction:", direction);
-                    return newLessons;
+                    if (targetIndex !== index) {
+                        const newLessons = [...prevLessons];
+                        [newLessons[targetIndex], newLessons[index]] = [newLessons[index], newLessons[targetIndex]];
+                        console.log("Moved lesson locally:", lessonId, "direction:", direction);
+                        return newLessons;
+                    }
+                    return prevLessons;
                 });
+            };
+
+            const handleChangeLessonCourse = (lessonId, newCourseId) => {
+                setLessons(prevLessons => prevLessons.map(l => l.id === lessonId ? { ...l, courseId: newCourseId } : l));
             };
 
             const handleDeleteLesson = async (lessonId) => {
@@ -719,6 +756,71 @@
                     }
                     console.log("Lesson deleted locally:", lessonId);
                 }
+            };
+
+            // --- Course Handlers ---
+            const handleCreateCourseSubmit = (e) => {
+                e.preventDefault();
+                if (!courseName.trim()) {
+                    setMessage({ text: "Tên khoá học không được để trống.", type: "error" });
+                    return;
+                }
+                const newCourse = { id: Date.now().toString(), name: courseName, expanded: true };
+                setCourses(prev => [...prev, newCourse]);
+                setCourseName('');
+                setView('lessonList');
+                setMessage({ text: "Khoá học đã được tạo!", type: "success" });
+            };
+
+            const handleEditCourse = (course) => {
+                setEditingCourse(course);
+                setCourseName(course.name);
+                setView('editCourse');
+            };
+
+            const handleUpdateCourseSubmit = (e) => {
+                e.preventDefault();
+                if (!editingCourse) return;
+                if (!courseName.trim()) {
+                    setMessage({ text: "Tên khoá học không được để trống.", type: "error" });
+                    return;
+                }
+                setCourses(prev => prev.map(c => c.id === editingCourse.id ? { ...c, name: courseName } : c));
+                setCourseName('');
+                setEditingCourse(null);
+                setView('lessonList');
+                setMessage({ text: "Khoá học đã được cập nhật!", type: "success" });
+            };
+
+            const handleDeleteCourse = (courseId) => {
+                if (courses.length === 1) {
+                    alert('Không thể xóa khoá học cuối cùng.');
+                    return;
+                }
+                if (window.confirm("Xóa khoá học này? Các bài học sẽ được chuyển sang khoá đầu tiên.")) {
+                    const newCourses = courses.filter(c => c.id !== courseId);
+                    const targetId = newCourses[0].id;
+                    setLessons(prev => prev.map(l => l.courseId === courseId ? { ...l, courseId: targetId } : l));
+                    setCourses(newCourses);
+                }
+            };
+
+            const handleMoveCourse = (courseId, direction) => {
+                setCourses(prev => {
+                    const index = prev.findIndex(c => c.id === courseId);
+                    if (index === -1) return prev;
+                    const newCourses = [...prev];
+                    if (direction === 'up' && index > 0) {
+                        [newCourses[index - 1], newCourses[index]] = [newCourses[index], newCourses[index - 1]];
+                    } else if (direction === 'down' && index < newCourses.length - 1) {
+                        [newCourses[index + 1], newCourses[index]] = [newCourses[index], newCourses[index + 1]];
+                    }
+                    return newCourses;
+                });
+            };
+
+            const toggleCourseExpand = (courseId) => {
+                setCourses(prev => prev.map(c => c.id === courseId ? { ...c, expanded: !c.expanded } : c));
             };
 
             // --- Vocabulary Handlers ---
@@ -1655,6 +1757,7 @@
                         appId: "ChineseVocabApp_Local",
                         version: "1.0",
                         timestamp: new Date().toISOString(),
+                        courses: courses,
                         lessons: lessonsWithResolvedAudio,
                         studyGoal: {
                             targetDate: targetDate,
@@ -1709,10 +1812,15 @@
 
                                 console.log("Clearing existing localStorage and IndexedDB data...");
                                 localStorage.removeItem(LOCAL_STORAGE_KEY);
+                                localStorage.removeItem(COURSE_STORAGE_KEY);
                                 localStorage.removeItem('chineseTargetDate');
                                 localStorage.removeItem('chineseCheckInStreak');
                                 localStorage.removeItem('chineseLastCheckInDate');
                                 await clearAllAudioFiles();
+
+                                const importedCourses = (importedData.courses && importedData.courses.length > 0)
+                                    ? importedData.courses
+                                    : [{ id: `course-${Date.now()}`, name: 'Khoá học mặc định', expanded: true }];
 
                                 const newLessons = [];
                                 for (const lessonData of importedData.lessons) {
@@ -1797,8 +1905,9 @@
 
                                     const lessonCreatedAt = safeParseDate(lessonData.createdAt) || new Date();
                                     const lessonUpdatedAt = safeParseDate(lessonData.updatedAt);
-                                    newLessons.push({ 
-                                        ...lessonData, 
+                                    newLessons.push({
+                                        ...lessonData,
+                                        courseId: lessonData.courseId || importedCourses[0].id,
                                         vocabularies: newVocabularies,
                                         passages: newPassages,
                                         createdAt: lessonCreatedAt,
@@ -1806,6 +1915,7 @@
                                     });
                                 }
 
+                                setCourses(importedCourses);
                                 setLessons(newLessons);
 
                                 if (importedData.studyGoal) {
@@ -2100,21 +2210,28 @@
                     </div>
 
                     <h2 className="text-3xl font-bold text-gray-800 mb-6 flex justify-between items-center">
-                        Danh Sách Bài Học
-                        <button onClick={() => setView('createLesson')}
-                                className={`bg-indigo-500 text-white text-sm py-2 px-4 rounded-full hover:bg-indigo-600 transition-colors duration-200 shadow-md ${isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
-                                disabled={isProcessing}>
-                            <i className="fas fa-plus mr-1"></i> Tạo Bài Học Mới
-                        </button>
+                        Danh Sách Khoá Học
+                        <div className="space-x-2">
+                            <button onClick={() => { setCourseName(''); setView('createCourse'); }}
+                                    className={`bg-indigo-500 text-white text-sm py-2 px-4 rounded-full hover:bg-indigo-600 transition-colors duration-200 shadow-md ${isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                    disabled={isProcessing}>
+                                <i className="fas fa-folder-plus mr-1"></i> Tạo Khoá Học
+                            </button>
+                            <button onClick={() => { setLessonCourseId(courses[0]?.id || ''); setView('createLesson'); }}
+                                    className={`bg-indigo-500 text-white text-sm py-2 px-4 rounded-full hover:bg-indigo-600 transition-colors duration-200 shadow-md ${isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                    disabled={isProcessing}>
+                                <i className="fas fa-plus mr-1"></i> Tạo Bài Học
+                            </button>
+                        </div>
                     </h2>
-                    
+
                     <button onClick={() => promptForReviewLimit('allLessons')}
                             className={`w-full bg-green-600 text-white py-3 px-4 rounded-xl hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-all duration-200 shadow-md mb-6 ${allVocabularies.filter(v => v.meaning || v.pinyin || (v.examples && v.examples.some(ex => ex.chinese && ex.vietnamese && splitChineseSentence(ex.chinese).length > 1))).length === 0 || isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
                             disabled={allVocabularies.filter(v => v.meaning || v.pinyin || (v.examples && v.examples.some(ex => ex.chinese && ex.vietnamese && splitChineseSentence(ex.chinese).length > 1))).length === 0 || isProcessing}>
                         {isProcessing ? <LoadingSpinner /> : <i className="fas fa-play mr-2"></i>}
                         Ôn Tập Tất Cả Từ Vựng
                     </button>
-                    
+
                     <button onClick={() => promptForReviewLimit('difficultWords', null, true)}
                             className={`w-full bg-red-600 text-white py-3 px-4 rounded-xl hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-all duration-200 shadow-md mb-6 ${allVocabularies.filter(v => v.wrongAttempts >= 2).length === 0 || isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
                             disabled={allVocabularies.filter(v => v.wrongAttempts >= 2).length === 0 || isProcessing}>
@@ -2124,67 +2241,122 @@
 
                     {error ? (
                         <MessageBox message={error} type="error" />
-                    ) : lessons.length === 0 ? (
-                        <p className="text-gray-600 text-center py-8">Chưa có bài học nào. Hãy tạo một bài mới!</p>
+                    ) : courses.length === 0 ? (
+                        <p className="text-gray-600 text-center py-8">Chưa có khoá học nào. Hãy tạo một khoá mới!</p>
                     ) : (
                         <div className="space-y-4">
-                            {lessons.map((lesson, index) => (
-                                <div key={lesson.id} className={`bg-gray-50 p-4 rounded-xl shadow-sm border border-gray-200 ${lesson.isTemp ? 'opacity-70 animate-pulse' : ''}`}>
-                                    <div className="flex justify-between items-start mb-2">
-                                        <div>
-                                            <h3 className="text-xl font-bold text-gray-900">{lesson.name}</h3>
-                                            <p className="text-gray-500 text-sm">Tạo lúc: {lesson.createdAt.toLocaleDateString('vi-VN')} | Từ vựng: {(lesson.vocabularies || []).length}</p>
+                            {courses.map((course, cIndex) => {
+                                const lessonsInCourse = lessons.filter(l => l.courseId === course.id);
+                                return (
+                                    <div key={course.id} className="bg-gray-100 p-4 rounded-xl shadow-sm border border-gray-300">
+                                        <div className="flex justify-between items-start mb-2">
+                                            <div>
+                                                <h3 className="text-2xl font-bold text-gray-900">{course.name}</h3>
+                                            </div>
+                                            <div className="flex space-x-2">
+                                                <button onClick={() => handleMoveCourse(course.id, 'up')}
+                                                        className={`bg-gray-400 text-white text-xs p-2 rounded-full hover:bg-gray-500 transition-colors duration-200 ${cIndex === 0 || isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                                        title="Di chuyển khoá học lên"
+                                                        disabled={cIndex === 0 || isProcessing}>
+                                                    <i className="fas fa-arrow-up"></i>
+                                                </button>
+                                                <button onClick={() => handleMoveCourse(course.id, 'down')}
+                                                        className={`bg-gray-400 text-white text-xs p-2 rounded-full hover:bg-gray-500 transition-colors duration-200 ${cIndex === courses.length - 1 || isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                                        title="Di chuyển khoá học xuống"
+                                                        disabled={cIndex === courses.length - 1 || isProcessing}>
+                                                    <i className="fas fa-arrow-down"></i>
+                                                </button>
+                                                <button onClick={() => handleEditCourse(course)}
+                                                        className={`bg-blue-500 text-white text-xs p-2 rounded-full hover:bg-blue-600 transition-colors duration-200 ${isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                                        title="Chỉnh Sửa Khoá Học"
+                                                        disabled={isProcessing}>
+                                                    <i className="fas fa-edit"></i>
+                                                </button>
+                                                <button onClick={() => toggleCourseExpand(course.id)}
+                                                        className={`bg-blue-500 text-white text-xs p-2 rounded-full hover:bg-blue-600 transition-colors duration-200 ${isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                                        title="Thu gọn/Mở rộng"
+                                                        disabled={isProcessing}>
+                                                    <i className={`fas ${course.expanded ? 'fa-chevron-up' : 'fa-chevron-down'}`}></i>
+                                                </button>
+                                                <button onClick={() => handleDeleteCourse(course.id)}
+                                                        className={`bg-red-500 text-white text-xs p-2 rounded-full hover:bg-red-600 transition-colors duration-200 ${isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                                        title="Xóa Khoá Học"
+                                                        disabled={isProcessing}>
+                                                    <i className="fas fa-trash"></i>
+                                                </button>
+                                            </div>
                                         </div>
-                                        <div className="flex space-x-2">
-                                            <button onClick={() => handleMoveLesson(lesson.id, 'up')}
-                                                    className={`bg-gray-400 text-white text-xs p-2 rounded-full hover:bg-gray-500 transition-colors duration-200 ${index === 0 || isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
-                                                    title="Di chuyển lên"
-                                                    disabled={index === 0 || isProcessing}>
-                                                <i className="fas fa-arrow-up"></i>
-                                            </button>
-                                            <button onClick={() => handleMoveLesson(lesson.id, 'down')}
-                                                    className={`bg-gray-400 text-white text-xs p-2 rounded-full hover:bg-gray-500 transition-colors duration-200 ${index === lessons.length - 1 || isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
-                                                    title="Di chuyển xuống"
-                                                    disabled={index === lessons.length - 1 || isProcessing}>
-                                                <i className="fas fa-arrow-down"></i>
-                                            </button>
-
-                                            <button onClick={() => handleEditLesson(lesson)}
-                                                    className={`bg-blue-500 text-white text-xs p-2 rounded-full hover:bg-blue-600 transition-colors duration-200 ${isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
-                                                    title="Chỉnh Sửa Bài Học"
-                                                    disabled={isProcessing}>
-                                                <i className="fas fa-edit"></i>
-                                            </button>
-                                            <button onClick={() => { setView('vocabularyList'); setSelectedLesson(lesson); }}
-                                                    className={`bg-blue-500 text-white text-xs p-2 rounded-full hover:bg-blue-600 transition-colors duration-200 ${isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
-                                                    title="Xem Từ Vựng"
-                                                    disabled={isProcessing}>
-                                                <i className="fas fa-list-alt"></i>
-                                            </button>
-                                            <button onClick={() => { setView('passageList'); setSelectedLesson(lesson); }}
-                                                    className={`bg-purple-500 text-white text-xs p-2 rounded-full hover:bg-purple-600 transition-colors duration-200 ${isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
-                                                    title="Quản Lý Bài Khóa"
-                                                    disabled={isProcessing}>
-                                                <i className="fas fa-file-alt"></i>
-                                            </button>
-                                            <button onClick={() => promptForReviewLimit('singleLesson', lesson)}
-                                                    className={`bg-green-500 text-white text-xs p-2 rounded-full hover:bg-green-600 transition-colors duration-200 ${
-                                                        (lessons.find(l => l.id === lesson.id)?.vocabularies?.filter(v => v.meaning || v.pinyin || (v.examples && v.examples.some(ex => ex.chinese && ex.vietnamese && splitChineseSentence(ex.chinese).length > 1)))?.length || 0) === 0 || isProcessing ? 'opacity-50 cursor-not-allowed' : ''
-                                                    }`}
-                                                    title="Ôn Tập Bài Học Này"
-                                                    disabled={(lessons.find(l => l.id === lesson.id)?.vocabularies?.filter(v => v.meaning || v.pinyin || (v.examples && v.examples.some(ex => ex.chinese && ex.vietnamese && splitChineseSentence(ex.chinese).length > 1)))?.length || 0) === 0 || isProcessing}>
-                                                {isProcessing ? <LoadingSpinner /> : <i className="fas fa-book-open"></i>}
-                                            </button>
-                                            <button onClick={() => handleDeleteLesson(lesson.id)}
-                                                    className={`bg-red-500 text-white text-xs p-2 rounded-full hover:bg-red-600 transition-colors duration-200 ${isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
-                                                    title="Xóa Bài Học"
-                                                    disabled={isProcessing}>
-                                                <i className="fas fa-trash"></i>
-                                            </button>
-                                        </div>
+                                        {course.expanded && (
+                                            <div className="mt-2 space-y-4">
+                                                {lessonsInCourse.length === 0 ? (
+                                                    <p className="text-gray-600 text-sm">Chưa có bài học nào.</p>
+                                                ) : (
+                                                    lessonsInCourse.map((lesson, index) => (
+                                                        <div key={lesson.id} className={`bg-gray-50 p-4 rounded-xl shadow-sm border border-gray-200 ${lesson.isTemp ? 'opacity-70 animate-pulse' : ''}`}>
+                                                            <div className="flex justify-between items-start mb-2">
+                                                                <div>
+                                                                    <h4 className="text-xl font-bold text-gray-900">{lesson.name}</h4>
+                                                                    <p className="text-gray-500 text-sm">Tạo lúc: {lesson.createdAt.toLocaleDateString('vi-VN')} | Từ vựng: {(lesson.vocabularies || []).length}</p>
+                                                                </div>
+                                                                <div className="flex space-x-2 items-center">
+                                                                    <select value={lesson.courseId} onChange={e => handleChangeLessonCourse(lesson.id, e.target.value)}
+                                                                            className="text-xs border rounded p-1">
+                                                                        {courses.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+                                                                    </select>
+                                                                    <button onClick={() => handleMoveLesson(lesson.id, 'up')}
+                                                                            className={`bg-gray-400 text-white text-xs p-2 rounded-full hover:bg-gray-500 transition-colors duration-200 ${index === 0 || isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                                                            title="Di chuyển lên"
+                                                                            disabled={index === 0 || isProcessing}>
+                                                                        <i className="fas fa-arrow-up"></i>
+                                                                    </button>
+                                                                    <button onClick={() => handleMoveLesson(lesson.id, 'down')}
+                                                                            className={`bg-gray-400 text-white text-xs p-2 rounded-full hover:bg-gray-500 transition-colors duration-200 ${index === lessonsInCourse.length - 1 || isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                                                            title="Di chuyển xuống"
+                                                                            disabled={index === lessonsInCourse.length - 1 || isProcessing}>
+                                                                        <i className="fas fa-arrow-down"></i>
+                                                                    </button>
+                                                                    <button onClick={() => handleEditLesson(lesson)}
+                                                                            className={`bg-blue-500 text-white text-xs p-2 rounded-full hover:bg-blue-600 transition-colors duration-200 ${isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                                                            title="Chỉnh Sửa Bài Học"
+                                                                            disabled={isProcessing}>
+                                                                        <i className="fas fa-edit"></i>
+                                                                    </button>
+                                                                    <button onClick={() => { setView('vocabularyList'); setSelectedLesson(lesson); }}
+                                                                            className={`bg-blue-500 text-white text-xs p-2 rounded-full hover:bg-blue-600 transition-colors duration-200 ${isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                                                            title="Xem Từ Vựng"
+                                                                            disabled={isProcessing}>
+                                                                        <i className="fas fa-list-alt"></i>
+                                                                    </button>
+                                                                    <button onClick={() => { setView('passageList'); setSelectedLesson(lesson); }}
+                                                                            className={`bg-purple-500 text-white text-xs p-2 rounded-full hover:bg-purple-600 transition-colors duration-200 ${isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                                                            title="Quản Lý Bài Khóa"
+                                                                            disabled={isProcessing}>
+                                                                        <i className="fas fa-file-alt"></i>
+                                                                    </button>
+                                                                    <button onClick={() => promptForReviewLimit('singleLesson', lesson)}
+                                                                            className={`bg-green-500 text-white text-xs p-2 rounded-full hover:bg-green-600 transition-colors duration-200 ${
+                                                                                (lessons.find(l => l.id === lesson.id)?.vocabularies?.filter(v => v.meaning || v.pinyin || (v.examples && v.examples.some(ex => ex.chinese && ex.vietnamese && splitChineseSentence(ex.chinese).length > 1)))?.length || 0) === 0 || isProcessing ? 'opacity-50 cursor-not-allowed' : ''
+                                                                            }`}
+                                                                            title="Ôn Tập Bài Học Này"
+                                                                            disabled={(lessons.find(l => l.id === lesson.id)?.vocabularies?.filter(v => v.meaning || v.pinyin || (v.examples && v.examples.some(ex => ex.chinese && ex.vietnamese && splitChineseSentence(ex.chinese).length > 1)))?.length || 0) === 0 || isProcessing}>
+                                                                        {isProcessing ? <LoadingSpinner /> : <i className="fas fa-book-open"></i>}
+                                                                    </button>
+                                                                    <button onClick={() => handleDeleteLesson(lesson.id)}
+                                                                            className={`bg-red-500 text-white text-xs p-2 rounded-full hover:bg-red-600 transition-colors duration-200 ${isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                                                            title="Xóa Bài Học"
+                                                                            disabled={isProcessing}>
+                                                                        <i className="fas fa-trash"></i>
+                                                                    </button>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    ))
+                                                )}
+                                            </div>
+                                        )}
                                     </div>
-                                </div>
-                            ))}
+                                );
+                            })}
                         </div>
                     )}
                     {renderReviewLimitModal()}
@@ -2200,6 +2372,14 @@
                         <input type="text" id="lessonName" value={lessonName} onChange={(e) => setLessonName(e.target.value)} required
                                className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-indigo-500 focus:border-indigo-500"
                                disabled={isProcessing} />
+                    </div>
+                    <div>
+                        <label htmlFor="lessonCourse" className="block text-sm font-medium text-gray-700">Khoá Học:</label>
+                        <select id="lessonCourse" value={lessonCourseId} onChange={e => setLessonCourseId(e.target.value)}
+                                className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-indigo-500 focus:border-indigo-500"
+                                disabled={isProcessing}>
+                            {courses.map(course => <option key={course.id} value={course.id}>{course.name}</option>)}
+                        </select>
                     </div>
                     <button type="submit"
                             className={`w-full bg-indigo-600 text-white py-3 px-4 rounded-xl hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-all duration-200 shadow-md ${isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
@@ -2224,12 +2404,66 @@
                                className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-indigo-500 focus:border-indigo-500"
                                disabled={isProcessing} />
                     </div>
+                    <div>
+                        <label htmlFor="lessonCourseEdit" className="block text-sm font-medium text-gray-700">Khoá Học:</label>
+                        <select id="lessonCourseEdit" value={lessonCourseId} onChange={e => setLessonCourseId(e.target.value)}
+                                className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-indigo-500 focus:border-indigo-500"
+                                disabled={isProcessing}>
+                            {courses.map(course => <option key={course.id} value={course.id}>{course.name}</option>)}
+                        </select>
+                    </div>
                     <button type="submit"
                             className={`w-full bg-indigo-600 text-white py-3 px-4 rounded-xl hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-all duration-200 shadow-md ${isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
                             disabled={isProcessing}>
                         {isProcessing ? <LoadingSpinner /> : <i className="fas fa-save mr-2"></i>} Lưu Chỉnh Sửa
                     </button>
                     <button type="button" onClick={() => { setView('lessonList'); setLessonName(''); setEditingLesson(null); }}
+                            className="w-full mt-2 bg-gray-300 text-gray-800 py-3 px-4 rounded-xl hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 transition-all duration-200 shadow-md"
+                            disabled={isProcessing}>
+                        <i className="fas fa-times mr-2"></i> Hủy
+                    </button>
+                </form>
+            );
+
+            const renderCreateCourseForm = () => (
+                <form onSubmit={handleCreateCourseSubmit} className="space-y-4 relative">
+                    {isProcessing && <div className="form-overlay"><LoadingSpinner /><p className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-center text-lg font-semibold text-gray-700 mt-16">Đang tạo...</p></div>}
+                    <h2 className="text-3xl font-bold text-gray-800 mb-6">Tạo Khoá Học Mới</h2>
+                    <div>
+                        <label htmlFor="courseName" className="block text-sm font-medium text-gray-700">Tên Khoá Học:</label>
+                        <input type="text" id="courseName" value={courseName} onChange={e => setCourseName(e.target.value)} required
+                               className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-indigo-500 focus:border-indigo-500"
+                               disabled={isProcessing} />
+                    </div>
+                    <button type="submit"
+                            className={`w-full bg-indigo-600 text-white py-3 px-4 rounded-xl hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-all duration-200 shadow-md ${isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
+                            disabled={isProcessing}>
+                        {isProcessing ? <LoadingSpinner /> : <i className="fas fa-plus mr-2"></i>} Tạo Khoá Học
+                    </button>
+                    <button type="button" onClick={() => setView('lessonList')}
+                            className="w-full mt-2 bg-gray-300 text-gray-800 py-3 px-4 rounded-xl hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 transition-all duration-200 shadow-md"
+                            disabled={isProcessing}>
+                        <i className="fas fa-arrow-left mr-2"></i> Quay Lại
+                    </button>
+                </form>
+            );
+
+            const renderEditCourseForm = () => (
+                <form onSubmit={handleUpdateCourseSubmit} className="space-y-4 relative">
+                    {isProcessing && <div className="form-overlay"><LoadingSpinner /><p className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-center text-lg font-semibold text-gray-700 mt-16">Đang lưu...</p></div>}
+                    <h2 className="text-3xl font-bold text-gray-800 mb-6">Chỉnh Sửa Khoá Học: <span className="text-indigo-600">{editingCourse?.name}</span></h2>
+                    <div>
+                        <label htmlFor="courseNameEdit" className="block text-sm font-medium text-gray-700">Tên Khoá Học Mới:</label>
+                        <input type="text" id="courseNameEdit" value={courseName} onChange={e => setCourseName(e.target.value)} required
+                               className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-indigo-500 focus:border-indigo-500"
+                               disabled={isProcessing} />
+                    </div>
+                    <button type="submit"
+                            className={`w-full bg-indigo-600 text-white py-3 px-4 rounded-xl hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-all duration-200 shadow-md ${isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
+                            disabled={isProcessing}>
+                        {isProcessing ? <LoadingSpinner /> : <i className="fas fa-save mr-2"></i>} Lưu Khoá Học
+                    </button>
+                    <button type="button" onClick={() => { setView('lessonList'); setCourseName(''); setEditingCourse(null); }}
                             className="w-full mt-2 bg-gray-300 text-gray-800 py-3 px-4 rounded-xl hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 transition-all duration-200 shadow-md"
                             disabled={isProcessing}>
                         <i className="fas fa-times mr-2"></i> Hủy
@@ -3797,6 +4031,8 @@
                         {view === 'lessonList' && renderLessonList()}
                         {view === 'createLesson' && renderCreateLessonForm()}
                         {view === 'editLesson' && renderEditLessonForm()}
+                        {view === 'createCourse' && renderCreateCourseForm()}
+                        {view === 'editCourse' && renderEditCourseForm()}
                         {view === 'vocabularyList' && renderVocabularyList()}
                         {view === 'createVocabulary' && renderCreateVocabularyForm()}
                         {view === 'editVocabulary' && renderEditVocabularyForm()}


### PR DESCRIPTION
## Summary
- Introduce course entities with local storage persistence
- Group lessons under collapsible, re-orderable courses
- Allow moving lessons between courses and include course data in import/export

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68957ae6fd388322aa6ffef9138ec379