### PR TITLE
feat: add flashcard review mode

### DIFF
--- a/RoadtoGlory v0.4.html
+++ b/RoadtoGlory v0.4.html
@@ -368,6 +368,7 @@
             const [showReviewLimitModal, setShowReviewLimitModal] = useState({ isVisible: false, isDifficult: false });
             const [tempReviewLimit, setTempReviewLimit] = useState('');
             const [reviewSourceVocabs, setReviewSourceVocabs] = useState([]);
+            const [isCardFlipped, setIsCardFlipped] = useState(false);
             
             // For rearrangeExample question type
             const [scrambledWords, setScrambledWords] = useState([]);
@@ -1445,6 +1446,73 @@
                 console.log(`Review session started with total questions:`, questionsToAsk.length);
             };
 
+            const startFlashcardReview = () => {
+                const validVocab = shuffleArray(allVocabularies.filter(v => v.hanTu));
+                if (validVocab.length === 0) {
+                    setMessage({ text: "Chưa có từ vựng nào để ôn tập.", type: "error" });
+                    return;
+                }
+                setReviewVocabList(validVocab);
+                setTotalQuestions(validVocab.length);
+                setCurrentQuestionNumber(0);
+                setIsCardFlipped(false);
+                setReviewMode('flashcard');
+                setView('review');
+            };
+
+            const handleFlashcardFlip = () => {
+                if (!reviewVocabList[currentQuestionNumber]) return;
+                if (!isCardFlipped) {
+                    const vocab = reviewVocabList[currentQuestionNumber];
+                    handlePlayDetailAudio(vocab.audioFile, vocab.hanTu);
+                }
+                setIsCardFlipped(!isCardFlipped);
+            };
+
+            const handleFlashcardPrev = () => {
+                if (currentQuestionNumber > 0) {
+                    setCurrentQuestionNumber(prev => prev - 1);
+                    setIsCardFlipped(false);
+                }
+            };
+
+            const handleFlashcardNext = () => {
+                if (currentQuestionNumber < reviewVocabList.length - 1) {
+                    setCurrentQuestionNumber(prev => prev + 1);
+                    setIsCardFlipped(false);
+                }
+            };
+
+            const handleFlashcardMark = (isAnswerCorrect) => {
+                const vocab = reviewVocabList[currentQuestionNumber];
+                if (!vocab) return;
+                const vocabId = vocab.id;
+                setLessons(prevLessons =>
+                    prevLessons.map(lesson => ({
+                        ...lesson,
+                        vocabularies: lesson.vocabularies.map(v =>
+                            v.id === vocabId
+                                ? (isAnswerCorrect
+                                    ? {
+                                        ...v,
+                                        correctStreak: (v.correctStreak || 0) + 1,
+                                        wrongAttempts: (v.correctStreak || 0) + 1 >= CORRECT_STREAK_TO_GRADUATE ? 0 : v.wrongAttempts
+                                      }
+                                    : {
+                                        ...v,
+                                        wrongAttempts: (v.wrongAttempts || 0) + 1,
+                                        correctStreak: 0
+                                      })
+                                : v
+                        )
+                    }))
+                );
+                if (currentQuestionNumber < reviewVocabList.length - 1) {
+                    setCurrentQuestionNumber(prev => prev + 1);
+                    setIsCardFlipped(false);
+                }
+            };
+
 
             const handleOptionClick = async (index) => {
                 if (selectedOption !== null) return;
@@ -2237,6 +2305,13 @@
                             disabled={allVocabularies.filter(v => v.wrongAttempts >= 2).length === 0 || isProcessing}>
                         {isProcessing ? <LoadingSpinner /> : <i className="fas fa-exclamation-triangle mr-2"></i>}
                         Ôn Tập Từ Khó ({allVocabularies.filter(v => v.wrongAttempts >= 2).length})
+                    </button>
+
+                    <button onClick={startFlashcardReview}
+                            className={`w-full bg-yellow-500 text-white py-3 px-4 rounded-xl hover:bg-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:ring-offset-2 transition-all duration-200 shadow-md mb-6 ${allVocabularies.length === 0 || isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
+                            disabled={allVocabularies.length === 0 || isProcessing}>
+                        {isProcessing ? <LoadingSpinner /> : <i className="fas fa-clone mr-2"></i>}
+                        Ôn Tập Flashcard
                     </button>
 
                     {error ? (
@@ -3774,7 +3849,61 @@
                 );
             };
 
-            const renderReviewGame = () => (
+            const renderFlashcard = () => {
+                const vocab = reviewVocabList[currentQuestionNumber];
+                if (!vocab) {
+                    return <p className="text-gray-600 text-center py-8">Không có thẻ nào để ôn tập.</p>;
+                }
+                return (
+                    <>
+                        <h2 className="text-3xl font-bold text-gray-800 mb-6 flex justify-between items-center">
+                            Flashcards ({currentQuestionNumber + 1} / {totalQuestions})
+                            <label className="flex items-center space-x-2 text-base font-normal">
+                                <input
+                                    type="checkbox"
+                                    checked={showPinyin}
+                                    onChange={(e) => setShowPinyin(e.target.checked)}
+                                    className="form-checkbox h-5 w-5 text-indigo-600 rounded"
+                                    disabled={isProcessing}
+                                />
+                                <span>Hiện Bính Âm</span>
+                            </label>
+                        </h2>
+                        <div className="flex justify-center" onClick={handleFlashcardFlip}>
+                            <div className="w-80 h-52 cursor-pointer" style={{ perspective: '1000px' }}>
+                                <div className="relative w-full h-full transition-transform duration-500" style={{ transformStyle: 'preserve-3d', transform: isCardFlipped ? 'rotateY(180deg)' : 'rotateY(0deg)' }}>
+                                    <div className="absolute w-full h-full flex items-center justify-center bg-white rounded-xl shadow-xl text-5xl font-bold" style={{ backfaceVisibility: 'hidden' }}>
+                                        {vocab.hanTu}
+                                    </div>
+                                    <div className="absolute w-full h-full bg-indigo-100 rounded-xl shadow-xl p-4 text-center flex flex-col items-center justify-center" style={{ backfaceVisibility: 'hidden', transform: 'rotateY(180deg)' }}>
+                                        {vocab.image && <img src={vocab.image} alt={vocab.hanTu} className="w-16 h-16 mb-2 rounded" />}
+                                        {showPinyin && <p className="text-2xl text-indigo-800 mb-2">{vocab.pinyin}</p>}
+                                        <p className="text-gray-700 mb-2">{vocab.hanVietMeaning && <span className="text-gray-500">[{vocab.hanVietMeaning}] </span>}{vocab.meaning}</p>
+                                        {vocab.examples && vocab.examples.map((ex, idx) => (
+                                            ex.chinese && ex.vietnamese && <p key={idx} className="text-sm text-gray-600">{ex.chinese} - {ex.vietnamese}</p>
+                                        ))}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div className="mt-6 flex justify-center space-x-4">
+                            <button onClick={handleFlashcardPrev} className="bg-gray-300 text-gray-800 py-2 px-4 rounded-lg hover:bg-gray-400"><i className="fas fa-arrow-left mr-1"></i>Trước</button>
+                            <button onClick={() => handleFlashcardMark(true)} className="bg-green-500 text-white py-2 px-4 rounded-lg hover:bg-green-600">Đúng</button>
+                            <button onClick={() => handleFlashcardMark(false)} className="bg-red-500 text-white py-2 px-4 rounded-lg hover:bg-red-600">Sai</button>
+                            <button onClick={handleFlashcardNext} className="bg-gray-300 text-gray-800 py-2 px-4 rounded-lg hover:bg-gray-400">Sau<i className="fas fa-arrow-right ml-1"></i></button>
+                        </div>
+                        <button onClick={() => { setView('lessonList'); setReviewMode(''); setIsCardFlipped(false); }} className="w-full mt-8 bg-gray-300 text-gray-800 py-3 px-4 rounded-xl hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 transition-all duration-200 shadow-md">
+                            <i className="fas fa-arrow-left mr-2"></i> Quay Lại Danh Sách Bài Học
+                        </button>
+                    </>
+                );
+            };
+
+            const renderReviewGame = () => {
+                if (reviewMode === 'flashcard') {
+                    return renderFlashcard();
+                }
+                return (
                 <>
                     <h2 className="text-3xl font-bold text-gray-800 mb-6 flex justify-between items-center">
                         Ôn Tập ({currentQuestionNumber + 1} / {totalQuestions})
@@ -4020,6 +4149,7 @@
                     )}
                 </>
             );
+            };
 
             return (
                 <div className="min-h-screen bg-gradient-to-br from-indigo-500 via-purple-500 to-pink-500 flex items-center justify-center p-4">


### PR DESCRIPTION
## Summary
- add flashcard review mode with flipping cards and audio playback
- include new review menu button to start flashcard sessions
- track correct and incorrect answers to update vocab stats

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68958890d8b883229453bd269f5f06fc