### PR TITLE
feat: add global hanzi popup utility

### DIFF
--- a/RoadtoGlory v0.4.html
+++ b/RoadtoGlory v0.4.html
@@ -315,6 +315,104 @@
         };
 
 
+        // Reusable popup utility for Chinese word definitions
+        const useHanziPopup = (allVocabularies, normalizeHanTu, stopSpeaking) => {
+            const [popupWord, setPopupWord] = useState(null);
+            const popupRef = useRef(null);
+
+            useEffect(() => {
+                const closePopup = () => {
+                    setPopupWord(null);
+                    if (popupRef.current) popupRef.current.style.display = 'none';
+                };
+
+                const handleClick = (event) => {
+                    const container = event.target.closest('[data-chinese]');
+                    if (!container) return;
+
+                    stopSpeaking();
+
+                    let bestMatch = null;
+                    const sentenceText = container.dataset.chinese;
+                    const charSpan = event.target.closest('.hanzi-char-span');
+
+                    if (charSpan && charSpan.dataset.index != null) {
+                        const clickedIndex = parseInt(charSpan.dataset.index, 10);
+                        for (let len = 5; len >= 1; len--) {
+                            for (let start = clickedIndex - len + 1; start <= clickedIndex; start++) {
+                                if (start < 0) continue;
+                                const end = start + len;
+                                if (end > sentenceText.length) continue;
+                                const potential = sentenceText.substring(start, end);
+                                if (!potential.match(/^[\u4e00-\u9fff\u3400-\u4DBF]+$/)) continue;
+                                const found = allVocabularies.find(v =>
+                                    normalizeHanTu(v.hanTu) === normalizeHanTu(potential)
+                                );
+                                if (found) {
+                                    bestMatch = found;
+                                    break;
+                                }
+                            }
+                            if (bestMatch) break;
+                        }
+                    } else {
+                        const found = allVocabularies.find(v =>
+                            normalizeHanTu(v.hanTu) === normalizeHanTu(sentenceText)
+                        );
+                        if (found) bestMatch = found;
+                    }
+
+                    if (bestMatch) {
+                        setPopupWord(bestMatch);
+                        const { clientX, clientY } = event;
+                        const popupWidth = 300;
+                        const popupHeight = 250;
+                        const mainContent = document.querySelector('.max-w-7xl');
+                        const mainRect = mainContent ? mainContent.getBoundingClientRect() : { left: 0, top: 0, right: window.innerWidth, bottom: window.innerHeight };
+                        let left = clientX + 10;
+                        let top = clientY + 10;
+                        if (left + popupWidth > mainRect.right) left = clientX - popupWidth - 10;
+                        if (top + popupHeight > mainRect.bottom) top = clientY - popupHeight - 10;
+                        if (left < mainRect.left) left = mainRect.left + 10;
+                        if (top < mainRect.top) top = mainRect.top + 10;
+                        if (popupRef.current) {
+                            popupRef.current.style.left = `${left}px`;
+                            popupRef.current.style.top = `${top}px`;
+                            popupRef.current.style.display = 'block';
+                        }
+                    } else {
+                        closePopup();
+                    }
+                };
+
+                const handleClickOutside = (event) => {
+                    if (popupRef.current && !popupRef.current.contains(event.target)) {
+                        if (!event.target.closest('[data-chinese]')) {
+                            closePopup();
+                        }
+                    }
+                };
+
+                const handleEscape = (event) => {
+                    if (event.key === 'Escape') {
+                        closePopup();
+                    }
+                };
+
+                document.addEventListener('click', handleClick);
+                document.addEventListener('mousedown', handleClickOutside);
+                document.addEventListener('keydown', handleEscape);
+
+                return () => {
+                    document.removeEventListener('click', handleClick);
+                    document.removeEventListener('mousedown', handleClickOutside);
+                    document.removeEventListener('keydown', handleEscape);
+                };
+            }, [allVocabularies]);
+
+            return { popupWord, setPopupWord, popupRef };
+        };
+
         // --- Main App Component ---
         const App = () => {
             const [courses, setCourses] = useState([]);
@@ -392,11 +490,9 @@
             const [sentenceInput, setSentenceInput] = useState('');
             const [fillInBlanksWords, setFillInBlanksWords] = useState([]);
             const [dictationCorrectAnswer, setDictationCorrectAnswer] = useState('');
-            const [popupWord, setPopupWord] = useState(null);
-            const popupRef = useRef(null);
 
             // Passage playback rate state
-            const [passagePlaybackRate, setPassagePlaybackRate] = useState(1); 
+            const [passagePlaybackRate, setPassagePlaybackRate] = useState(1);
 
             // Ref for controlling full passage playback
             const isPlayingAllPassage = useRef(false);
@@ -1173,6 +1269,7 @@
                 return sentence.split(/\s+|(?=[\u4e00-\u9fff])|(?<=[\u4e00-\u9fff])/).filter(word => word.trim() !== '');
             };
 
+            const { popupWord, setPopupWord, popupRef } = useHanziPopup(allVocabularies, normalizeHanTu, stopSpeaking);
 
             const displayQuestion = async (questionIndex, vocabList) => {
                 if (!vocabList || vocabList.length === 0 || questionIndex >= vocabList.length) {
@@ -2295,7 +2392,7 @@
                                                         <div key={lesson.id} className={`bg-gray-50 p-4 rounded-xl shadow-sm border border-gray-200 ${lesson.isTemp ? 'opacity-70 animate-pulse' : ''}`}>
                                                             <div className="flex justify-between items-start mb-2">
                                                                 <div>
-                                                                    <h4 className="text-xl font-bold text-gray-900">{lesson.name}</h4>
+                                                                    <h4 className="text-xl font-bold text-gray-900" data-chinese={lesson.name}>{lesson.name}</h4>
                                                                     <p className="text-gray-500 text-sm">Tạo lúc: {lesson.createdAt.toLocaleDateString('vi-VN')} | Từ vựng: {(lesson.vocabularies || []).length}</p>
                                                                 </div>
                                                                 <div className="flex space-x-2 items-center">
@@ -2499,7 +2596,11 @@
                                     <div className="flex justify-between items-start mb-2">
                                         <div>
                                             <div className="flex items-center space-x-2">
-                                                <h3 className="text-xl font-bold text-gray-900">{vocab.hanTu}</h3>
+                                                <h3 className="text-xl font-bold text-gray-900" data-chinese={vocab.hanTu}>
+                                                    {vocab.hanTu.split('').map((char, idx) => (
+                                                        <span key={idx} className="hanzi-char-span inline-block cursor-pointer hover:bg-blue-100 rounded-sm px-1 py-0.5" data-index={idx}>{char}</span>
+                                                    ))}
+                                                </h3>
                                                 {vocab.hanTu && (
                                                     <button onClick={() => handlePlayDetailAudio(vocab.audioFile, vocab.hanTu)}
                                                             className="text-indigo-600 hover:text-indigo-800 text-lg focus:outline-none"
@@ -2543,7 +2644,12 @@
                                                                 <i className="fas fa-volume-up"></i>
                                                             </button>
                                                         )}
-                                                        <span>{ex.chinese} <span className="text-gray-500">- {ex.vietnamese}</span></span>
+                                                        <span data-chinese={ex.chinese}>
+                                                            {ex.chinese.split('').map((char, cIdx) => (
+                                                                <span key={cIdx} className="hanzi-char-span inline-block cursor-pointer hover:bg-blue-100 rounded-sm px-1 py-0.5" data-index={cIdx}>{char}</span>
+                                                            ))}
+                                                            <span className="text-gray-500">- {ex.vietnamese}</span>
+                                                        </span>
                                                     </li>
                                                 ))}
                                             </ul>
@@ -3093,117 +3199,6 @@
             };
 
 
-            // NEW: Handle click for word pop-up (Reading Mode) - ADVANCED MATCHING
-            const handleWordClickInPassage = (event, sentenceText) => {
-                stopSpeaking();
-                setPopupWord(null);
-                if (popupRef.current) popupRef.current.style.display = 'none';
-
-                const clickedElement = event.target;
-                if (!clickedElement.classList.contains('hanzi-char-span')) return;
-
-                const textContentBefore = Array.from(clickedElement.parentNode.childNodes)
-                                            .slice(0, Array.from(clickedElement.parentNode.childNodes).indexOf(clickedElement))
-                                            .map(node => node.textContent)
-                                            .join('');
-                const clickedCharIndexInSentence = textContentBefore.length;
-
-                let bestMatch = null;
-                const MAX_WORD_LEN = 4; 
-
-                for (let len = MAX_WORD_LEN; len >= 1; len--) {
-                    for (let startOffset = 0; startOffset < len; startOffset++) {
-                        const wordStart = clickedCharIndexInSentence - startOffset;
-                        if (wordStart < 0) continue; 
-
-                        const wordEnd = wordStart + len;
-                        if (wordEnd > sentenceText.length) continue; 
-
-                        const potentialWordHanTu = sentenceText.substring(wordStart, wordEnd);
-                        if (!potentialWordHanTu.match(/^[\u4e00-\u9fff\u3400-\u4DBF]+$/)) continue; 
-
-                        const foundVocab = allVocabularies.find(vocab => 
-                            normalizeHanTu(vocab.hanTu) === normalizeHanTu(potentialWordHanTu)
-                        );
-
-                        if (foundVocab) {
-                            bestMatch = foundVocab;
-                            break;
-                        }
-                    }
-                    if (bestMatch) break;
-                }
-
-
-                if (bestMatch) {
-                    setPopupWord(bestMatch);
-                    console.log("Found best match for popup:", bestMatch);
-                    if (popupRef.current) {
-                        const { clientX, clientY } = event;
-                        const popupWidth = 300; 
-                        const popupHeight = 250; 
-
-                        const mainContent = document.querySelector('.max-w-7xl');
-                        const mainContentRect = mainContent ? mainContent.getBoundingClientRect() : { left: 0, top: 0, right: window.innerWidth, bottom: window.innerHeight };
-
-                        let left = clientX + 10;
-                        let top = clientY + 10;
-
-                        if (left + popupWidth > mainContentRect.right) {
-                            left = clientX - popupWidth - 10;
-                            if (left < mainContentRect.left) {
-                                left = mainContentRect.right - popupWidth - 10;
-                            }
-                        }
-                        if (top + popupHeight > mainContentRect.bottom) {
-                            top = clientY - popupHeight - 10;
-                            if (top < mainContentRect.top) {
-                                top = mainContentRect.bottom - popupHeight - 10;
-                            }
-                        }
-                        if (left < mainContentRect.left) left = mainContentRect.left + 10;
-                        if (top < mainContentRect.top) top = mainContentRect.top + 10;
-                        
-                        popupRef.current.style.left = `${left}px`;
-                        popupRef.current.style.top = `${top}px`;
-                        popupRef.current.style.display = 'block';
-                    }
-                } else {
-                    setPopupWord(null);
-                    if (popupRef.current) {
-                        popupRef.current.style.display = 'none';
-                    }
-                }
-            };
-
-            useEffect(() => {
-                const handleClickOutside = (event) => {
-                    if (popupRef.current && !popupRef.current.contains(event.target)) {
-                        let isHanziSpanOrPassageText = false;
-                        let targetElement = event.target;
-                        while(targetElement && targetElement !== document.body) {
-                            if (targetElement.classList.contains('hanzi-char-span') || targetElement.classList.contains('passage-sentence-text')) {
-                                isHanziSpanOrPassageText = true; 
-                                break;
-                            }
-                            targetElement = targetElement.parentElement;
-                        }
-
-                        if (!isHanziSpanOrPassageText) { 
-                            setPopupWord(null);
-                            if (popupRef.current) {
-                                popupRef.current.style.display = 'none';
-                            }
-                        }
-                    }
-                };
-                document.addEventListener('mousedown', handleClickOutside);
-                return () => {
-                    document.removeEventListener('mousedown', handleClickOutside);
-                };
-            }, []); 
-
-
             const setupFillInBlanks = () => {
                 if (!selectedPassage || !selectedPassage.sentences || selectedPassage.sentences.length === 0) return;
 
@@ -3631,10 +3626,10 @@
                                             </button>
                                             <div className="flex-grow">
                                                 {sentence.speaker && <span className="font-bold mr-2 text-gray-700">{sentence.speaker}：</span>}
-                                                <span className="passage-sentence-text">
+                                                <span className="passage-sentence-text" data-chinese={sentence.chinese}>
                                                     {sentence.chinese.split('').map((char, index) => (
                                                         <span key={`${sIdx}-${index}`}
-                                                              onClick={(e) => handleWordClickInPassage(e, sentence.chinese)}
+                                                              data-index={index}
                                                               className="hanzi-char-span inline-block cursor-pointer hover:bg-blue-100 rounded-sm px-1 py-0.5 transition-colors duration-100">
                                                             {char}
                                                         </span>


### PR DESCRIPTION
## Summary
- extract popupWord logic into reusable listener for Chinese text
- enable click-to-define on lessons, vocabulary, and example sentences
- ensure popup positions near selection and closes on outside click or Escape

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68958894c9b0832292e4e596905087fb