### PR TITLE
feat: allow selecting review question types

### DIFF
--- a/RoadtoGlory v0.4.html
+++ b/RoadtoGlory v0.4.html
@@ -96,6 +96,17 @@
         // Correct streak required to "graduate" a difficult word
         const CORRECT_STREAK_TO_GRADUATE = 10;
 
+        const QUESTION_TYPES_STORAGE_KEY = 'selectedQuestionTypes';
+        const QUESTION_TYPE_LABELS = {
+            translateWord: 'Hán tự -> Nghĩa Việt (MC)',
+            typePinyin: 'Hán tự -> Gõ Bính âm',
+            translateMeaning: 'Hán tự -> Nghĩa Việt (MC, VN options)',
+            translateVietToHanTuMC: 'Tiếng Việt -> Chọn Hán tự (MC)',
+            translateExample: 'Ví dụ Trung -> Nghĩa Việt (MC)',
+            typeHanTu: 'Tiếng Việt -> Gõ Hán tự',
+            rearrangeExample: 'Sắp xếp từ thành câu'
+        };
+
         // --- IndexedDB Helper Functions ---
         const openDB = () => {
             return new Promise((resolve, reject) => {
@@ -368,7 +379,8 @@
             const [showReviewLimitModal, setShowReviewLimitModal] = useState({ isVisible: false, isDifficult: false });
             const [tempReviewLimit, setTempReviewLimit] = useState('');
             const [reviewSourceVocabs, setReviewSourceVocabs] = useState([]);
-            
+            const [selectedQuestionTypes, setSelectedQuestionTypes] = useState([]);
+
             // For rearrangeExample question type
             const [scrambledWords, setScrambledWords] = useState([]);
             const [selectedWords, setSelectedWords] = useState([]);
@@ -544,6 +556,11 @@
                         setLastCheckInDate(new Date(storedLastCheckInDate));
                     }
 
+                    const storedSelectedTypes = localStorage.getItem(QUESTION_TYPES_STORAGE_KEY);
+                    if (storedSelectedTypes) {
+                        setSelectedQuestionTypes(JSON.parse(storedSelectedTypes));
+                    }
+
                 } catch (e) {
                     console.error("Failed to load data from localStorage:", e);
                     setError("Lỗi khi tải dữ liệu từ bộ nhớ cục bộ. Dữ liệu có thể bị hỏng. Vui lòng thử xóa dữ liệu trình duyệt và nhập lại backup nếu có.");
@@ -599,6 +616,12 @@
                     localStorage.setItem(COURSE_STORAGE_KEY, JSON.stringify(courses));
                 }
             }, [courses, loading]);
+
+            useEffect(() => {
+                if (!loading) {
+                    localStorage.setItem(QUESTION_TYPES_STORAGE_KEY, JSON.stringify(selectedQuestionTypes));
+                }
+            }, [selectedQuestionTypes, loading]);
 
             useEffect(() => {
                 if (selectedLesson) {
@@ -1228,8 +1251,15 @@
                     setQuestion(null);
                     return;
                 }
-                
-                const randomQuestionType = shuffleArray(availableQuestionTypes)[0];
+
+                let questionTypePool = availableQuestionTypes;
+                if (selectedQuestionTypes.length > 0) {
+                    const filtered = availableQuestionTypes.filter(t => selectedQuestionTypes.includes(t));
+                    if (filtered.length > 0) {
+                        questionTypePool = filtered;
+                    }
+                }
+                const randomQuestionType = shuffleArray(questionTypePool)[0];
                 setQuestionType(randomQuestionType);
                 setPinyinInput('');
                 setHanTuInput('');
@@ -1378,6 +1408,12 @@
                 console.log("Displayed question for review:", questionData);
             };
 
+            const toggleQuestionType = (type) => {
+                setSelectedQuestionTypes(prev =>
+                    prev.includes(type) ? prev.filter(t => t !== type) : [...prev, type]
+                );
+            };
+
             const promptForReviewLimit = (mode, lesson = null, isDifficult = false) => {
                 setReviewMode(mode);
                 setSelectedLesson(lesson);
@@ -1389,6 +1425,11 @@
                 const limit = parseInt(tempReviewLimit, 10);
                 let actualLimit = limit;
                 const { isVisible, isDifficult } = showReviewLimitModal;
+
+                if (selectedQuestionTypes.length === 0) {
+                    setMessage({ text: "Vui lòng chọn ít nhất một dạng câu hỏi để ôn tập.", type: "error" });
+                    return;
+                }
 
                 let vocabForReview = [];
                 if (isDifficult) {
@@ -2127,16 +2168,29 @@
 
                 const { isVisible, isDifficult } = showReviewLimitModal;
 
-                return (
-                    <div className="modal-overlay">
-                        <div className="modal-content">
-                            <h3 className="text-xl font-bold text-gray-800 mb-4 text-center">Số câu hỏi muốn ôn tập?</h3>
-                            <p className="text-gray-700 text-sm mb-4 text-center">Để trống hoặc nhập 0 để ôn tất cả từ vựng hiện có.</p>
-                            <input
-                                type="number"
-                                value={tempReviewLimit}
-                                onChange={(e) => setTempReviewLimit(e.target.value)}
-                                placeholder="Tất cả"
+                  return (
+                      <div className="modal-overlay">
+                          <div className="modal-content">
+                              <h3 className="text-xl font-bold text-gray-800 mb-4 text-center">Số câu hỏi muốn ôn tập?</h3>
+                              <p className="text-gray-700 text-sm mb-4 text-center">Để trống hoặc nhập 0 để ôn tất cả từ vựng hiện có.</p>
+                              <div className="text-left mb-4 space-y-2">
+                                  {Object.entries(QUESTION_TYPE_LABELS).map(([type, label]) => (
+                                      <label key={type} className="flex items-center space-x-2">
+                                          <input
+                                              type="checkbox"
+                                              checked={selectedQuestionTypes.includes(type)}
+                                              onChange={() => toggleQuestionType(type)}
+                                              className="form-checkbox"
+                                          />
+                                          <span>{label}</span>
+                                      </label>
+                                  ))}
+                              </div>
+                              <input
+                                  type="number"
+                                  value={tempReviewLimit}
+                                  onChange={(e) => setTempReviewLimit(e.target.value)}
+                                  placeholder="Tất cả"
                                 min="0"
                                 className="w-full border border-gray-300 rounded-md shadow-sm p-2 text-sm focus:ring-indigo-500 focus:border-indigo-500 text-center mb-4"
                             />


### PR DESCRIPTION
## Summary
- Add persistent question type selection with checkboxes
- Filter generated questions by user selections and ensure at least one type chosen

## Testing
- `npm test` *(fails: could not read package.json)*
- `npm run lint` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689588930e4483229a0c63df170a4e1c