### PR TITLE
refactor: constrain main content width

### DIFF
--- a/RoadtoGlory v0.6.html
+++ b/RoadtoGlory v0.6.html
@@ -3075,7 +3075,7 @@
                         const popupWidth = 300; 
                         const popupHeight = 250; 
 
-                        const mainContent = document.querySelector('.max-w-7xl');
+                        const mainContent = document.querySelector('.max-w-screen-lg');
                         const mainContentRect = mainContent ? mainContent.getBoundingClientRect() : { left: 0, top: 0, right: window.innerWidth, bottom: window.innerHeight };
 
                         let left = clientX + 10;
@@ -4022,11 +4022,11 @@
             );
 
             return (
-                <div className="min-h-screen bg-gradient-to-br from-indigo-500 via-purple-500 to-pink-500 flex items-center justify-center p-4">
+                <div className="min-h-screen bg-gradient-to-br from-indigo-500 via-purple-500 to-pink-500 flex items-center justify-center px-4 sm:px-6 py-4">
                     {loading && <FullPageLoadingOverlay message="Đang tải dữ liệu từ bộ nhớ cục bộ..." />}
                     {/* Main Content Container - Increased max-w-4xl for larger UI (was max-w-2xl) */}
                     {/* Dòng gây lỗi đã bị loại bỏ khỏi đây */}
-                    <div className="bg-white bg-opacity-90 backdrop-blur-md p-8 rounded-3xl shadow-2xl w-full max-w-7xl text-left transform transition-all duration-300">
+                    <div className="bg-white bg-opacity-90 backdrop-blur-md py-8 px-4 sm:px-6 rounded-3xl shadow-2xl w-full max-w-screen-lg mx-auto text-left transform transition-all duration-300">
                         {renderMessageBox()}
                         {view === 'lessonList' && renderLessonList()}
                         {view === 'createLesson' && renderCreateLessonForm()}


### PR DESCRIPTION
## Summary
- limit main content container to `max-w-screen-lg` and center it
- add responsive horizontal padding to layout
- update popup positioning logic to target the new container width class

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895ab8ab7f48322aaa62ef6c8b0b108